### PR TITLE
Add CocoaPods and Androidx Support for RN 0.60+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,90 +16,11 @@ yarn add react-native-pinch
 
 ## Automatically link
 
-#### With React Native 0.27+
+#### With React Native 0.60+
 
 ```shell
-react-native link react-native-pinch
-```
-
-#### With older versions of React Native
-
-You need [`rnpm`](https://github.com/rnpm/rnpm) (`npm install -g rnpm`)
-
-```shell
-rnpm link react-native-pinch
-```
-
-## Manually link
-
-### iOS (via Cocoa Pods)
-Add the following line to your build targets in your `Podfile`
-
-`pod 'RNPinch', :path => '../node_modules/react-native-pinch'`
-
-Then run `pod install`
-
-### Android
-
-- in `android/app/build.gradle`:
-
-```diff
-dependencies {
-    ...
-    compile "com.facebook.react:react-native:+"  // From node_modules
-+   compile project(':react-native-pinch')
-}
-```
-
-- in `android/settings.gradle`:
-
-```diff
-...
-include ':app'
-+ include ':react-native-pinch'
-+ project(':react-native-pinch').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-pinch/android')
-```
-
-#### With React Native 0.29+
-
-- in `MainApplication.java`:
-
-```diff
-+ import com.localz.PinchPackage;
-
-  public class MainApplication extends Application implements ReactApplication {
-    //......
-
-    @Override
-    protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-+         new PinchPackage(),
-          new MainReactPackage()
-      );
-    }
-
-    ......
-  }
-```
-
-#### With older versions of React Native:
-
-- in `MainActivity.java`:
-
-```diff
-+ import com.localz.PinchPackage;
-
-  public class MainActivity extends ReactActivity {
-    ......
-
-    @Override
-    protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-+       new PinchPackage(),
-        new MainReactPackage()
-      );
-    }
-  }
+cd ios
+pod install
 ```
 
 ## Adding certificates

--- a/RNPinch.podspec
+++ b/RNPinch.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, './package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "RNPinch"
+  s.version      = package['version']
+  s.summary      = package['description']
+
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.author       = 'Localz'
+  s.platform     = :ios, "9.0"
+  s.source       = { :git => "https://github.com/localz/react-native-pinch", :tag => "master" }
+  s.source_files  = "RNPinch/*.{h,m}"
+  s.requires_arc = true
+
+  s.dependency "React"
+
+end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,12 +7,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 24)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -1,7 +1,7 @@
 package com.localz;
 
 import android.os.AsyncTask;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.RequiresPermission;
 import android.util.Log;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageInfo;


### PR DESCRIPTION
This adds cocoapods support and moves to the androidx APIs in order to support react native 0.60+